### PR TITLE
Key error fixed

### DIFF
--- a/codes3d/codes3d.py
+++ b/codes3d/codes3d.py
@@ -1119,6 +1119,16 @@ def produce_summary(
         gene_exp[genes_tissues[i][0]][genes_tissues[i][1]] = expression[i][1]
 
     print("Computing HiC data...")
+
+    to_delete_snps_genes = []
+    for snp, gene in snps_genes:
+        try:
+            genes[snp][gene]
+        except KeyError:
+            to_delete_snps_genes.append((snp, gene))
+
+    snps_genes = [pair for pair in snps_genes if pair not in to_delete_snps_genes]
+
     hic_data = pool.map(calc_hic_contacts,
                         [genes[snp][gene] for snp, gene in snps_genes])
     global hic_dict


### PR DESCRIPTION
Hey guys,

I have no idea why your runs were complete successfully but all my runs were successfully failed, after 200+ hrs, with KeyError:

_Traceback (most recent call last):
 File “/mnt/3dgenome/projects/foffa/codes3d/codes3d_new/codes3d/produce_summary.py”, line 72, in <module>
   args.buffer_size_out, args.num_processes_summary)
 File “/mnt/3dgenome/projects/foffa/codes3d/codes3d_new/codes3d/codes3d.py”, line 1123, in produce_summary
   [genes[snp][gene] for snp, gene in snps_genes])
KeyError: ‘C2orf15’_

This happened because we somehow lost this check:

```
to_delete_snps_genes = []
     for snp, gene in snps_genes:
         try:
              genes[snp][gene]
         except KeyError:
              to_delete_snps_genes.append((snp, gene))

snps_genes = [pair for pair in snps_genes if pair not in to_delete_snps_genes]
```

I brought it back. If you don't like this part of the code or you think it makes produce_summary slower please improve it but do not remove. Thanks!